### PR TITLE
Add lexer tests for character literals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod expressions;
+pub mod lexer;
+pub mod parser;
+pub mod prelude;
+pub mod statements;
+pub mod type_checker;
+pub mod types;

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -1,0 +1,19 @@
+use som::lexer::{Lexer, TokenKind, TokenValue};
+
+#[test]
+fn ascii_character_literal_tokenizes() {
+    let mut lexer = Lexer::new("'a'");
+    let token = lexer.next().expect("expected token").expect("no error");
+    assert_eq!(token.kind, TokenKind::Character);
+    assert_eq!(token.value, TokenValue::Character('a'));
+    assert!(lexer.next().is_none());
+}
+
+#[test]
+fn multibyte_character_literal_tokenizes() {
+    let mut lexer = Lexer::new("'🦀'");
+    let token = lexer.next().expect("expected token").expect("no error");
+    assert_eq!(token.kind, TokenKind::Character);
+    assert_eq!(token.value, TokenValue::Character('🦀'));
+    assert!(lexer.next().is_none());
+}


### PR DESCRIPTION
## Summary
- add a small library target so integration tests can use crate modules
- add integration tests for the lexer covering ASCII and multi-byte characters

## Testing
- `cargo test --no-fail-fast` *(fails: failed to fetch crates index)*

------
https://chatgpt.com/codex/tasks/task_e_68571b797f2c83239cf7e7b7a2302081