### PR TITLE
Fix comment typo in token definition

### DIFF
--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -109,7 +109,7 @@ pub enum TokenKind {
 
     /// An equals sign; `=`.
     Equal,
-    /// A negetion sign; `!`.
+    /// A negation sign; `!`.
     Not,
     /// A less-than sign; `<`.
     LessThan,


### PR DESCRIPTION
## Summary
- fix a typo in `src/lexer/token.rs` describing the `Not` token

## Testing
- `cargo test` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68571b81870083239cdaeb597cd03a47